### PR TITLE
art: extend the supported cpu_variant list for arm64

### DIFF
--- a/runtime/arch/arm64/instruction_set_features_arm64.cc
+++ b/runtime/arch/arm64/instruction_set_features_arm64.cc
@@ -127,7 +127,8 @@ Arm64FeaturesUniquePtr Arm64InstructionSetFeatures::FromVariant(
         "exynos-m2",
         "exynos-m3",
         "kryo",
-        "kryo385",
+        "kryo300",
+        "kryo385"
     };
     if (!FindVariantInArray(arm64_known_variants, arraysize(arm64_known_variants), variant)) {
       std::ostringstream os;


### PR DESCRIPTION
add kryo300 to the supported cpu_variant list

Change-Id: Iad0dc93b4e99fe17af16cda5316b06ae4f17aa2c

Fixes:
Error parsing --instruction-set-variant=kryo300 message=Unexpected CPU variant for Arm64: kryo300